### PR TITLE
Fix PUPPI MET tails

### DIFF
--- a/CommonTools/PileupAlgos/plugins/PuppiPhoton.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiPhoton.cc
@@ -31,17 +31,19 @@ PuppiPhoton::PuppiPhoton(const edm::ParameterSet& iConfig) {
   tokenPFCandidates_     = consumes<CandidateView>(iConfig.getParameter<edm::InputTag>("candName"));
   tokenPuppiCandidates_  = consumes<CandidateView>(iConfig.getParameter<edm::InputTag>("puppiCandName"));
   tokenPhotonCandidates_ = consumes<CandidateView>(iConfig.getParameter<edm::InputTag>("photonName"));
-  tokenPhotonId_         = consumes<edm::ValueMap<bool>  >(iConfig.getParameter<edm::InputTag>("photonId")); 
+  reco2pf_               = mayConsume<edm::ValueMap<std::vector<reco::PFCandidateRef> > >(iConfig.getParameter<edm::InputTag>("recoToPFMap"));
+  tokenPhotonId_         = mayConsume<edm::ValueMap<bool>  >(iConfig.getParameter<edm::InputTag>("photonId"));
   pt_                    = iConfig.getParameter<double>("pt");
   eta_                   = iConfig.getParameter<double>("eta");
   dRMatch_               = iConfig.getParameter<std::vector<double> > ("dRMatch");
   pdgIds_                = iConfig.getParameter<std::vector<int32_t> >("pdgids");
+  runOnMiniAOD_          = iConfig.getParameter<bool>("runOnMiniAOD");
   usePFRef_              = iConfig.getParameter<bool>("useRefs");
   weight_                = iConfig.getParameter<double>("weight");
   useValueMap_           = iConfig.getParameter<bool>("useValueMap");
   tokenWeights_          = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("weightsName"));
 
-  usePhotonId_  = (iConfig.getParameter<edm::InputTag>("photonId")).label().size() == 0;
+  usePhotonId_  = (iConfig.getParameter<edm::InputTag>("photonId")).label().size() != 0;
   produces<PFOutputCollection>();
   produces< edm::ValueMap<reco::CandidatePtr> >(); 
 }
@@ -60,6 +62,9 @@ void PuppiPhoton::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   std::vector<const reco::Candidate*> phoCands;
   std::vector<uint16_t> phoIndx;
 
+  edm::Handle<edm::ValueMap<std::vector<reco::PFCandidateRef>>> reco2pf;
+  if(!runOnMiniAOD_) iEvent.getByToken(reco2pf_, reco2pf);
+
   // Get PFCandidate Collection
   edm::Handle<CandidateView> hPFProduct;
   iEvent.getByToken(tokenPFCandidates_,hPFProduct);
@@ -74,25 +79,32 @@ void PuppiPhoton::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     if(itPho->isPhoton() && usePhotonId_)   passObject =  (*photonId)  [phoCol->ptrAt(iC)];
     if(itPho->pt() < pt_) continue;
     if(!passObject && usePhotonId_) continue;
-    //if(!usePFRef_ && fabs(itPho->eta()) < eta_) phoCands.push_back(&(*itPho)); ===> should add a flag useAODRef_ in place of usePFRef_ 
-    //if(!usePFRef_) continue;
-    const pat::Photon *pPho = dynamic_cast<const pat::Photon*>(&(*itPho));
-    if(pPho != 0) {
-      for( const edm::Ref<pat::PackedCandidateCollection> & ref : pPho->associatedPackedPFCandidates() ) {
-	if(fabs(pfCol->ptrAt(ref.key())->eta()) < eta_ ) {
-	  phoIndx.push_back(ref.key());
-	  phoCands.push_back(&(*(pfCol->ptrAt(ref.key()))));
-	}
+    if(runOnMiniAOD_) {
+      const pat::Photon *pPho = dynamic_cast<const pat::Photon*>(&(*itPho));
+      if(pPho != 0) {
+        for( const edm::Ref<pat::PackedCandidateCollection> & ref : pPho->associatedPackedPFCandidates() ) {
+	  if(fabs(pfCol->ptrAt(ref.key())->eta()) < eta_ ) {
+	    phoIndx.push_back(ref.key());
+	    phoCands.push_back(&(*(pfCol->ptrAt(ref.key()))));
+	  }
+        }
+        continue;
       }
-      continue;
-    }
-    const pat::Electron *pElectron = dynamic_cast<const pat::Electron*>(&(*itPho));
-    if(pElectron != 0) {
-      for( const edm::Ref<pat::PackedCandidateCollection> & ref : pElectron->associatedPackedPFCandidates() ) 
-	if(fabs(pfCol->ptrAt(ref.key())->eta()) < eta_ )  {
-	  phoIndx.push_back(ref.key());
-	  phoCands.push_back(&(*(pfCol->ptrAt(ref.key()))));
-	}
+      const pat::Electron *pElectron = dynamic_cast<const pat::Electron*>(&(*itPho));
+      if(pElectron != 0) {
+        for( const edm::Ref<pat::PackedCandidateCollection> & ref : pElectron->associatedPackedPFCandidates() )
+	  if(fabs(pfCol->ptrAt(ref.key())->eta()) < eta_ )  {
+	    phoIndx.push_back(ref.key());
+	    phoCands.push_back(&(*(pfCol->ptrAt(ref.key()))));
+	  }
+      }
+    } else {
+      for( const edm::Ref<std::vector<reco::PFCandidate> > & ref : (*reco2pf)[phoCol->ptrAt(iC)] ) {
+	  if(fabs(pfCol->ptrAt(ref.key())->eta()) < eta_ )  {
+	    phoIndx.push_back(ref.key());
+	    phoCands.push_back(&(*(pfCol->ptrAt(ref.key()))));
+	  }
+      }
     }
   }
   //Get Weights
@@ -105,7 +117,7 @@ void PuppiPhoton::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   std::vector<float> lWeights;
   static const reco::PFCandidate dummySinceTranslateIsNotStatic;
   corrCandidates_.reset( new PFOutputCollection );
-  std::vector<int> foundPhoIndex;
+  std::set<int> foundPhoIndex;
   for(CandidateView::const_iterator itPF = pupCol->begin(); itPF!=pupCol->end(); itPF++) {  
     auto id = dummySinceTranslateIsNotStatic.translatePdgIdToType(itPF->pdgId());
     const reco::PFCandidate *pPF = dynamic_cast<const reco::PFCandidate*>(&(*itPF));
@@ -117,11 +129,11 @@ void PuppiPhoton::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
       int iPho = -1;
       for(std::vector<const reco::Candidate*>::iterator itPho = phoCands.begin(); itPho!=phoCands.end(); itPho++) {
 	iPho++;
-	if(!matchPFCandidate(&(*itPF),*itPho)) continue; 
+	if((!matchPFCandidate(&(*itPF),*itPho))||(foundPhoIndex.count(iPho)!=0)) continue;
         pWeight = weight_;
 	if(!useValueMap_ && itPF->pt() != 0) pWeight = pWeight*(phoCands[iPho]->pt()/itPF->pt());
 	if(!useValueMap_ && itPF->pt() == 0) pVec.SetPxPyPzE(phoCands[iPho]->px()*pWeight,phoCands[iPho]->py()*pWeight,phoCands[iPho]->pz()*pWeight,phoCands[iPho]->energy()*pWeight);
-        foundPhoIndex.push_back(iPho);      
+        foundPhoIndex.insert(iPho);
       }
     } else { 
       int iPho = -1;
@@ -131,7 +143,7 @@ void PuppiPhoton::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
         pWeight = weight_;
         if(!useValueMap_ && itPF->pt() != 0) pWeight = pWeight*(phoCands[iPho]->pt()/itPF->pt());
 	if(!useValueMap_ && itPF->pt() == 0) pVec.SetPxPyPzE(phoCands[iPho]->px()*pWeight,phoCands[iPho]->py()*pWeight,phoCands[iPho]->pz()*pWeight,phoCands[iPho]->energy()*pWeight);
-        foundPhoIndex.push_back(iPho);      
+        foundPhoIndex.insert(iPho);
       }
     }
     if(itPF->pt() != 0) pVec.SetPxPyPzE(itPF->px()*pWeight,itPF->py()*pWeight,itPF->pz()*pWeight,itPF->energy()*pWeight);
@@ -145,14 +157,7 @@ void PuppiPhoton::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   }
   //Add the missing pfcandidates
   for(unsigned int iPho = 0; iPho < phoCands.size(); iPho++) { 
-    bool pFound = false;
-    for(unsigned int jPho = 0; jPho < foundPhoIndex.size(); jPho++) { 
-      if(foundPhoIndex[jPho] == int(iPho)) {
-	pFound = true;
-	break;
-      }
-    }
-    if(pFound) continue;
+    if(foundPhoIndex.count(iPho)!=0) continue;
     auto id = dummySinceTranslateIsNotStatic.translatePdgIdToType(phoCands[iPho]->pdgId());
     reco::PFCandidate pCand(reco::PFCandidate(phoCands[iPho]->charge(), phoCands[iPho]->p4(),id) );
     pCand.setSourceCandidatePtr( phoCands[iPho]->sourceCandidatePtr(0) );

--- a/CommonTools/PileupAlgos/plugins/PuppiPhoton.h
+++ b/CommonTools/PileupAlgos/plugins/PuppiPhoton.h
@@ -34,11 +34,13 @@ private:
 	edm::EDGetTokenT< CandidateView >        tokenPFCandidates_;
 	edm::EDGetTokenT< CandidateView >        tokenPuppiCandidates_;
 	edm::EDGetTokenT< CandidateView >        tokenPhotonCandidates_;
+        edm::EDGetTokenT< edm::ValueMap<std::vector<reco::PFCandidateRef> > > reco2pf_;
 	edm::EDGetTokenT< edm::ValueMap<float> > tokenWeights_; 
 	edm::EDGetTokenT< edm::ValueMap<bool>  > tokenPhotonId_; 
 	double pt_;
 	double eta_;
 	bool   usePFRef_;
+	bool   runOnMiniAOD_;
 	bool   usePhotonId_;
 	std::vector<double>  dRMatch_;
 	std::vector<int32_t> pdgIds_; 

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -201,9 +201,8 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
         throw edm::Exception(edm::errors::LogicError,"PuppiProducer: cannot get weights since inputs are not PackedCandidates");
       }
       else{
-        // if (fUseWeightsNoLep){ curpupweight = itPF->puppiWeightNoLep(); }
-        // else{ curpupweight = itPF->puppiWeight();  }
-        curpupweight = lPack->puppiWeight();
+        if (fUseWeightsNoLep){ curpupweight = lPack->puppiWeightNoLep(); }
+        else{ curpupweight = lPack->puppiWeight();  }
       }
       lWeights.push_back(curpupweight);
       fastjet::PseudoJet curjet( curpupweight*lPack->px(), curpupweight*lPack->py(), curpupweight*lPack->pz(), curpupweight*lPack->energy());

--- a/CommonTools/PileupAlgos/python/PhotonPuppi_cff.py
+++ b/CommonTools/PileupAlgos/python/PhotonPuppi_cff.py
@@ -2,12 +2,14 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
 
 puppiPhoton = cms.EDProducer("PuppiPhoton",
-                             candName       = cms.InputTag('packedPFCandidates'),
+                             candName       = cms.InputTag('particleFlow'),
                              puppiCandName  = cms.InputTag('puppi'),
-                             photonName     = cms.InputTag('slimmedPhotons'),
+                             photonName     = cms.InputTag('reducedEgamma','reducedGedPhotons'),
+			     recoToPFMap    = cms.InputTag("reducedEgamma","reducedPhotonPfCandMap"),
                              photonId       = cms.InputTag("egmPhotonIDs:cutBasedPhotonID-Spring15-25ns-V1-standalone-loose"), 
                              pt             = cms.double(10),
                              eta            = cms.double(2.5),
+			     runOnMiniAOD   = cms.bool(False),
                              useRefs        = cms.bool(True),
                              dRMatch        = cms.vdouble(0.005,0.005,0.005,0.005),
                              pdgids         = cms.vint32 (22,11,211,130),

--- a/CommonTools/PileupAlgos/python/PhotonPuppi_cff.py
+++ b/CommonTools/PileupAlgos/python/PhotonPuppi_cff.py
@@ -6,7 +6,7 @@ puppiPhoton = cms.EDProducer("PuppiPhoton",
                              puppiCandName  = cms.InputTag('puppi'),
                              photonName     = cms.InputTag('reducedEgamma','reducedGedPhotons'),
 			     recoToPFMap    = cms.InputTag("reducedEgamma","reducedPhotonPfCandMap"),
-                             photonId       = cms.InputTag("egmPhotonIDs:cutBasedPhotonID-Spring15-25ns-V1-standalone-loose"), 
+                             photonId       = cms.InputTag("egmPhotonIDs:cutBasedPhotonID-Spring16-V2p2-loose"), 
                              pt             = cms.double(10),
                              eta            = cms.double(2.5),
 			     runOnMiniAOD   = cms.bool(False),
@@ -20,14 +20,14 @@ puppiPhoton = cms.EDProducer("PuppiPhoton",
 
 
 def setupPuppiPhoton(process):
-    my_id_modules = ['RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_Spring15_25ns_V1_cff']
+    my_id_modules = ['RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_Spring16_V2p2_cff']
     switchOnVIDPhotonIdProducer(process, DataFormat.AOD)
     for idmod in my_id_modules:
         setupAllVIDIdsInModule(process,idmod,setupVIDPhotonSelection)
 
 
 def setupPuppiPhotonMiniAOD(process):
-    my_id_modules = ['RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_Spring15_25ns_V1_cff']
+    my_id_modules = ['RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_Spring16_V2p2_cff']
     switchOnVIDPhotonIdProducer(process, DataFormat.MiniAOD)
     for idmod in my_id_modules:
         setupAllVIDIdsInModule(process,idmod,setupVIDPhotonSelection)

--- a/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
@@ -49,8 +49,8 @@ def makePuppiesFromMiniAOD( process, createScheduledSequence=False ):
     #Line below points puppi MET to puppi no lepton which increases the response
     process.puppiForMET.puppiCandName    = 'puppiMerged'
     #Avoid recomputing the weights available in MiniAOD
-    process.puppi.useExistingWeights = True
-    process.puppiNoLep.useExistingWeights = True
+    #process.puppi.useExistingWeights = True
+    #process.puppiNoLep.useExistingWeights = True
 
     #making a sequence for people running the MET tool in scheduled mode
     if createScheduledSequence:

--- a/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
@@ -21,7 +21,7 @@ def makePuppies( process ):
     process.puppiMerged = cms.EDProducer("CandViewMerger",src = cms.VInputTag( 'puppiNoLep','pfLeptonsPUPPET'))
     process.load('CommonTools.PileupAlgos.PhotonPuppi_cff')
     process.puppiForMET = process.puppiPhoton.clone()
-    #Line below replaces reference linking wiht delta R matching this is because the reference key in packed candidates differs to PF candidates (must be done when reading Reco)
+    #Line below replaces reference linking wiht delta R matching because the puppi references after merging are not consistent with those of the original PF collection
     process.puppiForMET.useRefs          = False
     #Line below points puppi MET to puppi no lepton which increases the response
     process.puppiForMET.puppiCandName    = 'puppiMerged'
@@ -40,10 +40,17 @@ def makePuppiesFromMiniAOD( process, createScheduledSequence=False ):
     process.puppiMerged = cms.EDProducer("CandViewMerger",src = cms.VInputTag( 'puppiNoLep','pfLeptonsPUPPET'))
     process.load('CommonTools.PileupAlgos.PhotonPuppi_cff')
     process.puppiForMET = process.puppiPhoton.clone()
+    process.puppiForMET.candName = cms.InputTag('packedPFCandidates')
+    process.puppiForMET.photonName = cms.InputTag('slimmedPhotons')
+    process.puppiForMET.runOnMiniAOD = cms.bool(True)
     setupPuppiPhotonMiniAOD(process)
-    #Line below doesn't work because of an issue with references in MiniAOD without setting useRefs=>False and using delta R
-    process.puppiForMET.puppiCandName    = 'puppiMerged'
+    #Line below replaces reference linking wiht delta R matching because the puppi references after merging are not consistent with those of the original packed candidate collection
     process.puppiForMET.useRefs          = False
+    #Line below points puppi MET to puppi no lepton which increases the response
+    process.puppiForMET.puppiCandName    = 'puppiMerged'
+    #Avoid recomputing the weights available in MiniAOD
+    process.puppi.useExistingWeights = True
+    process.puppiNoLep.useExistingWeights = True
 
     #making a sequence for people running the MET tool in scheduled mode
     if createScheduledSequence:

--- a/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/puppiForMET_cff.py
@@ -21,6 +21,7 @@ def makePuppies( process ):
     process.puppiMerged = cms.EDProducer("CandViewMerger",src = cms.VInputTag( 'puppiNoLep','pfLeptonsPUPPET'))
     process.load('CommonTools.PileupAlgos.PhotonPuppi_cff')
     process.puppiForMET = process.puppiPhoton.clone()
+    setupPuppiPhoton(process)
     #Line below replaces reference linking wiht delta R matching because the puppi references after merging are not consistent with those of the original PF collection
     process.puppiForMET.useRefs          = False
     #Line below points puppi MET to puppi no lepton which increases the response


### PR DESCRIPTION
This contains 2 fixes needed to remove tails of the PUPPI MET distribution:
- Photon ID was not applied in PUPPI Photon code
- PUPPI photon code was not protected against adding multiple copies of the same PF candidate in the output collected
Also the photon ID was updated for Moriond17.
The impact of this PR on jet and MET response and resolution has been validated.
Slide 17-22 show the impact of this change to MET:
https://indico.cern.ch/event/587258/contributions/2366495/attachments/1368938/2117761/satoshi_updatedAfterTheMeeting.pdf
What is labeled v10 is in the CMSSW_8_0_>=20 and CMSSW_8_1_X and CMSSW_9_0_X releases at the moment.
What is labeled "PFPUPPI v10 PHfix wgtRecal" is in this PR.

This PR changes the MINIAOD PUPPI MET collection, no changes to RECO/AOD event content.

90X version of this PR:  #17072