### PR TITLE
Make BadGlobalMuonTagger METFilter compliant.

### DIFF
--- a/RecoMET/METFilters/plugins/BadGlobalMuonTagger.cc
+++ b/RecoMET/METFilters/plugins/BadGlobalMuonTagger.cc
@@ -55,6 +55,7 @@ BadGlobalMuonTagger::BadGlobalMuonTagger(const edm::ParameterSet & iConfig) :
     taggingMode_(iConfig.getParameter<bool> ("taggingMode")),
     verbose_(iConfig.getUntrackedParameter<bool> ("verbose",false))
 {
+    produces<bool>();
     produces<edm::PtrVector<reco::Muon>>("bad");
 }
 
@@ -97,7 +98,7 @@ BadGlobalMuonTagger::filter(edm::Event & iEvent, const edm::EventSetup & iSetup)
         }
     }
 
-    bool found = false;
+    bool pass = true;
     for (unsigned int i = 0, n = muons.size(); i < n; ++i) {
         if (muons[i].pt() < ptCut_ || goodMuon[i] != 0) continue;
         if (verbose_) printf("potentially bad muon %d of pt %.1f eta %+.3f phi %+.3f\n", int(i+1), muons[i].pt(), muons[i].eta(), muons[i].phi());
@@ -116,13 +117,15 @@ BadGlobalMuonTagger::filter(edm::Event & iEvent, const edm::EventSetup & iSetup)
             }
         }
         if (bad) {
-            found = true;
+            pass = false;
             out->push_back(muons.ptrAt(i));
         }
     }
 
+    iEvent.put(std::auto_ptr<bool>(new bool(pass)));
     iEvent.put(std::move(out), "bad");
-    return taggingMode_ || found;
+
+    return taggingMode_ || pass;
 }
 
 

--- a/RecoMET/METFilters/python/badGlobalMuonTaggersAOD_cff.py
+++ b/RecoMET/METFilters/python/badGlobalMuonTaggersAOD_cff.py
@@ -11,5 +11,4 @@ cloneGlobalMuonTagger = badGlobalMuonTagger.clone(
     selectClones = True
 )
 
-noBadGlobalMuons = cms.Sequence(~cloneGlobalMuonTagger + ~badGlobalMuonTagger)
-    
+noBadGlobalMuons = cms.Sequence(cloneGlobalMuonTagger + badGlobalMuonTagger)

--- a/RecoMET/METFilters/python/badGlobalMuonTaggersMiniAOD_cff.py
+++ b/RecoMET/METFilters/python/badGlobalMuonTaggersMiniAOD_cff.py
@@ -11,5 +11,4 @@ cloneGlobalMuonTaggerMAOD = badGlobalMuonTaggerMAOD.clone(
     selectClones = True
 )
 
-noBadGlobalMuonsMAOD = cms.Sequence(~cloneGlobalMuonTaggerMAOD + ~badGlobalMuonTaggerMAOD)
-    
+noBadGlobalMuonsMAOD = cms.Sequence(cloneGlobalMuonTaggerMAOD + badGlobalMuonTaggerMAOD)


### PR DESCRIPTION
This PR changes the pass/fail logic of the BadGlobalMuonTagger in order be compliant with existing filter code. The changes are rather minor but somewhat required in order to [use this filter like any other MET filter](https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2?rev=103).

Instead of returning a found decision that denoted the existance of a found bad/duplicate muon, the filter now returns the pass decision. As a result, the module can be added to a sequence or path without sequence negation (~module/module.invert).

The module also produces a bool the store the pass decision now, that can be evaluated in following analyzers when using the tagging mode.